### PR TITLE
IN-9818: add Cloud Infra co-ownership of shared config files

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -4,7 +4,6 @@
 /.github/ @happyreturns/infrastructure-team @happyreturns/consumer-flow-team
 /.platform/ @happyreturns/infrastructure-team @happyreturns/consumer-flow-team
 **/Dockerfile @happyreturns/infrastructure-team @happyreturns/consumer-flow-team
-*.dockerfile @happyreturns/infrastructure-team @happyreturns/consumer-flow-team
 **/Chart.yaml @happyreturns/infrastructure-team @happyreturns/consumer-flow-team
 **/values.yaml @happyreturns/infrastructure-team @happyreturns/consumer-flow-team
 **/Makefile @happyreturns/infrastructure-team @happyreturns/consumer-flow-team

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,15 @@
 * @happyreturns/consumer-flow-team
 
+# Cloud Infra co-ownership — additive (IN-9796)
+/.github/ @happyreturns/infrastructure-team @happyreturns/consumer-flow-team
+/.platform/ @happyreturns/infrastructure-team @happyreturns/consumer-flow-team
+**/Dockerfile @happyreturns/infrastructure-team @happyreturns/consumer-flow-team
+*.dockerfile @happyreturns/infrastructure-team @happyreturns/consumer-flow-team
+**/Chart.yaml @happyreturns/infrastructure-team @happyreturns/consumer-flow-team
+**/values.yaml @happyreturns/infrastructure-team @happyreturns/consumer-flow-team
+**/Makefile @happyreturns/infrastructure-team @happyreturns/consumer-flow-team
+**/service.datadog.yaml @happyreturns/infrastructure-team @happyreturns/consumer-flow-team
+
 # For security of github workflows infrastructure must own CODEOWNERS and .github/workflows dir
 # IMPORTANT: This must be at the bottom of the CODEOWNERS file
 /.github/workflows @happyreturns/infrastructure-team


### PR DESCRIPTION
## What
Adds Cloud Infrastructure as an **additive co-owner** of shared config files in this repo's CODEOWNERS, per the approved proposal (IN-9796).

Co-owned paths: `/.github/`, `/.platform/`, `**/Dockerfile`, `*.dockerfile`, `**/Chart.yaml`, `**/values.yaml`, `**/Makefile`, `**/service.datadog.yaml`.

## Why
EITHER Cloud Infra OR the existing owner (@happyreturns/consumer-flow-team) can now approve changes to these paths, so org-wide infra / CI / security changes stop blocking on cross-team review. Ownership of everything else is unchanged.

## Guarantees
- **Additive only** — no existing owner or line removed or reordered.
- Security tail (`/.github/workflows`, `CODEOWNERS`) untouched and still infra-sole.
- `codeowners/errors` delta validated zero on this branch.

Proposal: https://happyreturns.atlassian.net/wiki/spaces/HRTW/pages/1388969987
Rollout: IN-9818 · Proposal: IN-9796